### PR TITLE
Fix relocated import location for kardianos/osext

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	"fmt"
 	"log"
 	//"os"


### PR DESCRIPTION
Looks like the original bitbucket location has disappeared so clean workspace builds fail now.