### PR TITLE
Bossac and ARM host support

### DIFF
--- a/compile_webidebridge.sh
+++ b/compile_webidebridge.sh
@@ -9,6 +9,10 @@ cp -r arduino/tools_linux_32  arduino/tools
 goxc -os="linux" -arch="386" --include="arduino/hardware,arduino/tools" -n="Arduino_WebIDE_Bridge" -d=.
 rm -rf arduino/tools
 
+cp -r arduino/tools_linux_arm  arduino/tools
+goxc -os="linux" -arch="arm" --include="arduino/hardware,arduino/tools" -n="Arduino_WebIDE_Bridge" -d=.
+rm -rf arduino/tools
+
 cp -r arduino/tools_windows  arduino/tools
 goxc -os="windows" --include="arduino/hardware,arduino/tools" -n="Arduino_WebIDE_Bridge" -d=.
 rm -rf arduino/tools

--- a/download.go
+++ b/download.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -25,13 +26,8 @@ func downloadFromUrl(url string) (filename string, err error) {
 	tokens := strings.Split(url, "/")
 	filePrefix := tokens[len(tokens)-1]
 	fmt.Println("The filePrefix is", filePrefix)
-	tmpfile, err := ioutil.TempFile(tmpdir, filePrefix)
-	if err != nil {
-		fmt.Println("Error creating tempfile. ", err)
-		return "", errors.New(err.Error() + " Could not create temp file to store downloaded file. Do you have permissions? Are you out of storage space?")
-	}
 
-	fileName := tmpfile.Name()
+	fileName, _ := filepath.Abs(tmpdir + "/" + filePrefix)
 	fmt.Println("Downloading", url, "to", fileName)
 
 	// TODO: check file existence first with io.IsExist

--- a/serial.go
+++ b/serial.go
@@ -721,7 +721,7 @@ func assembleCompilerCommand(boardname string, portname string, filePath string)
 	// if we are going to modify standard IDE files we also could pass ALL filename
 	filePath = strings.Trim(filePath, "\n")
 	boardOptions["build.path"] = filepath.Dir(filePath)
-	boardOptions["build.project_name"] = filepath.Base(filePath)
+	boardOptions["build.project_name"] = strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filepath.Base(filePath)))
 
 	file.Close()
 

--- a/serial.go
+++ b/serial.go
@@ -805,7 +805,7 @@ func assembleCompilerCommand(boardname string, portname string, filePath string)
 			log.Println(err)
 			return false, "", nil
 		}
-		port.SetDTR(false)
+		//port.SetDTR(false)
 		port.Close()
 		time.Sleep(time.Second / 2)
 		// time.Sleep(time.Second / 4)


### PR DESCRIPTION
This PR adds `bossac` support for all platforms (including ARM as host)
The `programfromurl` command has been slightly modified to save the file without changing its name

ARM support tested with a BeagleBone Black running ArchLinuxARM and programming a UNO and a DUE