### PR TITLE
Adding an initial delay to the regular status requests for GRBL.

### DIFF
--- a/bufferflow_grbl.go
+++ b/bufferflow_grbl.go
@@ -371,9 +371,11 @@ func (b *BufferflowGrbl) IsBufferGloballySendingBackIncomingData() bool {
 //'?' is asynchronous to the normal buffer load and does not need to be paused when buffer full
 func (b *BufferflowGrbl) rptQueryLoop(p *serport) {
 	b.parent_serport = p //make note of this port for use in clearing the buffer later, on error.
-	ticker := time.NewTicker(250 * time.Millisecond)
 	b.quit = make(chan int)
 	go func() {
+		duration := time.Duration(5)*time.Second
+		time.Sleep(duration)
+		ticker := time.NewTicker(500 * time.Millisecond)
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
The GRBL flow control would start sending '?' character immediately after connecting to the controller. GRBL Mega, and likely regular GRBL, often crash when they are queried before they are fully initialized. Adding an initial delay of five seconds to give grbl time to boot up completely solved this issue.